### PR TITLE
Async producer

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -89,6 +89,7 @@ func Clone(cmd *cobra.Command, args []string) {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt)
 
+Loop:
 	for {
 		select {
 		case msgC, ok := <-consumer.Messages():
@@ -108,10 +109,10 @@ func Clone(cmd *cobra.Command, args []string) {
 			}
 		case <-signals:
 			log.Print("terminating application")
-			return
+			break Loop
 		case <-time.After(time.Duration(timeout) * time.Millisecond):
 			log.Print("timeout - end of cloning")
-			return
+			break Loop
 		}
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -101,10 +101,7 @@ func Clone(cmd *cobra.Command, args []string) {
 					Key:   sarama.ByteEncoder(msgC.Key),
 					Value: sarama.ByteEncoder(msgC.Value),
 				}
-				_, _, err := producer.SendMessage(msgP)
-				if err != nil {
-					log.Printf("FAILED to send message %s\n", err)
-				}
+				producer.Input() <- msgP
 				if verbose {
 					log.Print("message produced")
 				}

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -9,6 +9,7 @@ import (
 
 //NewConsumer returns a new cluster consumer
 func NewConsumer(from string, brokers []string, consumerGroup string) *cluster.Consumer {
+
 	cfg := cluster.NewConfig()
 	cfg.Consumer.Return.Errors = true
 	cfg.Consumer.Offsets.Initial = sarama.OffsetOldest
@@ -36,9 +37,12 @@ func NewConsumer(from string, brokers []string, consumerGroup string) *cluster.C
 
 //NewProducer returns a new producer
 func NewProducer(brokers []string, defaultHasher bool) sarama.AsyncProducer {
+
 	cfg := sarama.NewConfig()
 	cfg.Producer.Return.Successes = true
 	cfg.Net.MaxOpenRequests = 1
+	cfg.Producer.RequiredAcks = sarama.WaitForAll
+
 	if defaultHasher {
 		cfg.Producer.Partitioner = sarama.NewCustomHashPartitioner(MurmurHasher)
 	}


### PR DESCRIPTION
Changed the sync producer to an async one, whch greatly increases performances.
The max open requests is limited to 1 to prevent events order modifications.