### PR TITLE
Cross cluster cloning

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -130,8 +130,12 @@ Loop:
 			if ok {
 				msgP := &sarama.ProducerMessage{
 					Topic: to,
-					Key:   sarama.ByteEncoder(msgC.Key),
-					Value: sarama.ByteEncoder(msgC.Value),
+				}
+				if msgC.Value != nil {
+					msgP.Value = sarama.ByteEncoder(msgC.Value)
+				}
+				if msgC.Key != nil {
+					msgP.Key = sarama.ByteEncoder(msgC.Key)
 				}
 				producer.Input() <- msgP
 				if verbose {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,25 +29,34 @@ import (
 )
 
 var (
-	verbose       bool
-	defaultHasher bool
-	force         bool
-	brokers       string
-	remoteBrokers string
-	from          string
-	to            string
-	timeout       int
-	consumerGroup = "kafka-topic-cloner"
+	verbose         bool
+	loop            bool
+	fromBrokers     string
+	toBrokers       string
+	from            string
+	to              string
+	hasher          string
+	timeout         int
+	consumerGroup   = "kafka-topic-cloner"
+	possibleHashers = []string{"murmur2", "FNV-1a"}
 )
 
 const appName = "kafka-topic-cloner"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "kafka-topic-cloner --brokers [url] --from [source] --to [target]",
+	Use:   "kafka-topic-cloner --from-brokers [url] --from [source] --to [target]",
 	Short: "Small cli used to clone the content of a topic into another one",
-	Long:  `Consumes all the events stored in the source topic, and produces them in the target topic. The two topics have to co-exist inside the same cluster.`,
-	Run:   Clone,
+	Long: `
+	Kafka topic cloner consumes all the events stored in the source topic, and produces them in the target topic.
+	The events will see their partitions re-assigned in the process, based on the hasher that you can specify.
+
+	Cloning between two different clusters can be achieved by using the --to-cluster flag.
+
+	Same-topic cloning (also called loop-cloning) is protected by the --loop flag. In this case, the source topic (--from) will be used as both source and target.
+	This can be a risky operation since it will multiply the messages in the source topic until manual interruption, use with caution!
+	`,
+	Run: Clone,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -60,17 +69,16 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose mode")
-	rootCmd.PersistentFlags().BoolVarP(&defaultHasher, "default-hasher", "d", false, "use the default sarama hasher for partitioning instead of murmur2")
-	rootCmd.PersistentFlags().BoolVarP(&force, "force", "F", false, "force cloning into the source topic")
-	rootCmd.PersistentFlags().StringVarP(&brokers, "brokers", "b", "", "semicolon-separated Kafka brokers URLs")
-	rootCmd.PersistentFlags().StringVarP(&remoteBrokers, "remote-brokers", "r", "", "semicolon-separated destination Kafka brokers URLs")
+	rootCmd.PersistentFlags().BoolVarP(&loop, "loop", "L", false, "loop mode (clone into the source topic)")
+	rootCmd.PersistentFlags().StringVarP(&fromBrokers, "from-brokers", "F", "", "address of the source kafka brokers, semicolon-separated")
+	rootCmd.PersistentFlags().StringVarP(&toBrokers, "to-brokers", "T", "", "address of the target kafka brokers, semicolon-separated (specify only if different from the source brokers)")
 	rootCmd.PersistentFlags().StringVarP(&from, "from", "f", "", "source topic")
 	rootCmd.PersistentFlags().StringVarP(&to, "to", "t", "", "target topic")
-	rootCmd.PersistentFlags().IntVarP(&timeout, "timeout", "o", 10000, "delay before timing out")
+	rootCmd.PersistentFlags().StringVarP(&hasher, "hasher", "H", "murmur2", "partitioning hasher (possible values: murmur2, FNV-1a")
+	rootCmd.PersistentFlags().IntVarP(&timeout, "timeout", "o", 10000, "delay (ms) before exiting after the last message has been cloned")
 
-	rootCmd.MarkPersistentFlagRequired("brokers")
+	rootCmd.MarkPersistentFlagRequired("from-brokers")
 	rootCmd.MarkPersistentFlagRequired("from")
-	rootCmd.MarkPersistentFlagRequired("to")
 }
 
 //Clone handles the consuming / producing process
@@ -81,19 +89,19 @@ func Clone(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	b := strings.Split(brokers, ";")
+	b := strings.Split(fromBrokers, ";")
 
 	consumer := kafka.NewConsumer(from, b, consumerGroup)
 	if verbose {
 		log.Printf("consumer (group: %s) initialized on %s/%s", consumerGroup, b, from)
 	}
 
-	if remoteBrokers != "" {
-		b = strings.Split(remoteBrokers, ";")
+	if toBrokers != "" {
+		b = strings.Split(toBrokers, ";")
 	}
-	producer := kafka.NewProducer(b, defaultHasher)
+	producer := kafka.NewProducer(b, hasher)
 	if verbose {
-		log.Printf("producer initialized on %s/%s, default hasher: %t", b, to, defaultHasher)
+		log.Printf("producer initialized on %s/%s, hasher: %s", b, to, hasher)
 	}
 
 	//Try to gracefully shutdown
@@ -144,17 +152,37 @@ Loop:
 
 func validateParameters() error {
 	switch true {
-	case brokers == "":
-		return errors.New("brokers must be set")
+
 	case from == "":
 		return errors.New("source topic must be set")
-	case to == "":
-		return errors.New("target topic must be set")
-	case from == to && !force:
-		return errors.New("same-topic cloning is disabled, use --force to ignore")
-	case brokers == remoteBrokers:
-		return errors.New("source and target brokers are the same, don't use --remote-brokers")
-	}
 
+	case to == "" && !loop:
+		return errors.New("target topic must be set")
+
+	case to != "" && loop:
+		return errors.New("do not specify target topic when loop-cloning")
+
+	case from == to && !loop && toBrokers == "":
+		return errors.New("cannot clone into the same topic without using --loop")
+
+	case fromBrokers == "":
+		return errors.New("source brokers must be set")
+
+	case fromBrokers == toBrokers:
+		return errors.New("source and target brokers are the same")
+
+	case !contains(possibleHashers, hasher):
+		return errors.New("unknown hasher, see help for possible values")
+
+	}
 	return nil
+}
+
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
 }

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -44,7 +44,7 @@ func NewConsumer(from string, brokers []string, consumerGroup string) *cluster.C
 }
 
 //NewProducer configures and returns an async producer
-func NewProducer(brokers []string, defaultHasher bool) sarama.AsyncProducer {
+func NewProducer(brokers []string, hasher string) sarama.AsyncProducer {
 
 	cfg := sarama.NewConfig()
 	cfg.Version = sarama.V1_0_0_0
@@ -59,7 +59,7 @@ func NewProducer(brokers []string, defaultHasher bool) sarama.AsyncProducer {
 	// Without this, cloning a high-volume topic will fail
 	cfg.Producer.Flush.Frequency = 100 * time.Millisecond
 
-	if !defaultHasher {
+	if hasher == "murmur2" {
 		cfg.Producer.Partitioner = sarama.NewCustomHashPartitioner(MurmurHasher)
 	}
 


### PR DESCRIPTION
* implemented --to-brokers (-T) parameter for cross-cluster cloning
* renamed --brokers (-b) -> --from-brokers (-F)
* hasher now replaces the default-hasher for better, and accepts a string as the desired hasher name
* nil keys are now correctly treated, and will trigger a random partitioning
* more parameter combinations are now verified before actually cloning (safety first!)
* documentation is up-to-date